### PR TITLE
Do not randomly generate invalid UTF-8 in the range 0xD800 through 0xDFFF...

### DIFF
--- a/src/main/java/org/kaazing/specification/ws/internal/Functions.java
+++ b/src/main/java/org/kaazing/specification/ws/internal/Functions.java
@@ -158,7 +158,7 @@ public final class Functions {
             break;
         case 3:
             // UTF-8 not legal for 0xD800 through 0xDFFF (see RFC 3269)
-            bytes[offset++] = (byte) (0xe0 | RANDOM.nextInt(0x08) | 1 << RANDOM.nextInt(4));
+            bytes[offset++] = (byte) (0xe0 | RANDOM.nextInt(0x08) | 1 << RANDOM.nextInt(3));
             bytes[offset++] = (byte) (0x80 | RANDOM.nextInt(0x40));
             bytes[offset++] = (byte) (0x80 | RANDOM.nextInt(0x40));
             break;


### PR DESCRIPTION
... (really)